### PR TITLE
Add desaturated style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,15 @@ RUN echo "STYLES: Downloading and modifying style files" \
  && /usr/src/sprites/node_modules/.bin/spritezero $STYLE_DIR/sprite $STYLE_DIR/icons \
  && /usr/src/sprites/node_modules/.bin/spritezero --retina $STYLE_DIR/sprite@2x $STYLE_DIR/icons \
  \
+ && STYLE=osm-bright-desaturated \
+ && STYLE_DIR=/styles/$STYLE \
+ && echo "Downloading style $STYLE" \
+ && mkdir -p $STYLE_DIR \
+ && curl -s -L https://github.com/elastic/$STYLE-gl-style/tarball/master | tar xz --strip=1 -C $STYLE_DIR \
+ && cat $STYLE_DIR/style.json | jq '.sources.openmaptiles.url = "mbtiles://{v3}" | .sprite = "{styleJsonFolder}/sprite" | .glyphs = "{fontstack}/{range}.pbf"' > $STYLE_DIR/style-local.json \
+ && /usr/src/sprites/node_modules/.bin/spritezero $STYLE_DIR/sprite $STYLE_DIR/icons \
+ && /usr/src/sprites/node_modules/.bin/spritezero --retina $STYLE_DIR/sprite@2x $STYLE_DIR/icons \
+ \
  && STYLE=positron \
  && STYLE_DIR=/styles/$STYLE \
  && echo "Downloading style $STYLE" \


### PR DESCRIPTION
This style is the same as osm-bright, except the colors are muted to match the CSS transforms in Kibana. Source repository for desaturated style is https://github.com/elastic/osm-bright-desaturated-gl-style.