### PR TITLE
Update to use elastic docker registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
+VERSION = 1.0.0
+IMAGE = push.docker.elastic.co/tileserver-gl-pack/tileserver-gl-pack:${VERSION}
+
 .PHONY: build
 build:
-	docker build . -t nyurik/tileserver-gl-pack -f Dockerfile
+	docker build -t ${IMAGE} .
 
 .PHONY: run
 run: build
-	docker run -it --rm tileserver-gl-pack
+	docker run -it --rm ${IMAGE}
 
 .PHONY: publish
 publish: build
-	docker push nyurik/tileserver-gl-pack
+	docker push ${IMAGE}

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Added styles:
 * dark-matter
 * klokanetech-basic
 * osm-bright
+* osm-bright-desaturated
 * positron
 
 # Running
 
 ```bash
-docker run -it --rm nyurik/tileserver-gl-pack <parameters>
+docker run -it --rm docker.elastic.co/tileserver-gl-pack/tileserver-gl-pack <parameters>
 ```
 
 # Testing Locally
-Uncomment ENTRYPOINT and CMD lines in the Dockerfile, and run this:
 
 ```bash
-docker build . -t tileserver-gl-pack -f Dockerfile && docker run -it --rm tileserver-gl-pack
+docker build . -t tileserver-gl-pack && docker run -it --rm --entrypoint "/bin/bash" tileserver-gl-pack
 ```


### PR DESCRIPTION
The container will be hosted on Elastic's docker registry. This updates the Makefile to match.