### PR TITLE
Use Elastic fork of dark-matter style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "STYLES: Downloading and modifying style files" \
  && STYLE_DIR=/styles/$STYLE \
  && echo "Downloading style $STYLE" \
  && mkdir -p $STYLE_DIR \
- && curl -s -L https://github.com/openmaptiles/$STYLE-gl-style/tarball/master | tar xz --strip=1 -C $STYLE_DIR \
+ && curl -s -L https://github.com/elastic/$STYLE-gl-style/tarball/master | tar xz --strip=1 -C $STYLE_DIR \
  && cat $STYLE_DIR/style.json | jq '.sources.openmaptiles.url = "mbtiles://{v3}" | .sprite = "{styleJsonFolder}/sprite" | .glyphs = "{fontstack}/{range}.pbf"' > $STYLE_DIR/style-local.json \
  && /usr/src/sprites/node_modules/.bin/spritezero $STYLE_DIR/sprite $STYLE_DIR/icons \
  && /usr/src/sprites/node_modules/.bin/spritezero --retina $STYLE_DIR/sprite@2x $STYLE_DIR/icons \


### PR DESCRIPTION
https://github.com/elastic/dark-matter-gl-style/pull/1 is a fork of the dark-matter style with changes consistent to other basemaps in Elastic Maps Service. So we should use that fork instead.